### PR TITLE
[FIX] add game status computations, added tracking to selected fields

### DIFF
--- a/virsat/models/vr_game_result.py
+++ b/virsat/models/vr_game_result.py
@@ -4,48 +4,48 @@ from datetime import datetime
 
 class VrGameResult(models.Model):
     _name = "vr.game.result"
+    _inherit = ['mail.thread']
     _description = "VR Game Result"
     _order = 'id desc'
 
-    name = fields.Char(string="PIN")
+    name = fields.Char(string="PIN", tracking=True)
     company_id = fields.Many2one('res.company', compute='get_company', store=True)
-    company_code = fields.Char()
+    company_code = fields.Char(tracking=True)
     vr_trainee_id = fields.Many2one('vr.trainee', compute='get_vr_trainee', string="Trainee", store=True)
     device_id = fields.Char()
     app_version = fields.Char()
     experience = fields.Char()
-    game_code = fields.Char()
+    game_code = fields.Char(tracking=True)
     vr_game_id = fields.Many2one('vr.games', compute="get_vr_game", string="Game", store=True)
-    level_code = fields.Char()
+    level_code = fields.Char(tracking=True)
     game_level_id = fields.Many2one('vr.game.levels', compute="get_vr_game_level", string="Game Level", store=True)
     session_id = fields.Char()
     game_session_id = fields.Many2one('vr.game.sessions')
-    session_start = fields.Datetime(compute="compute_session_start", store=True)
+    session_start = fields.Datetime(compute="compute_session_start", store=True, tracking=True)
     session_start_str = fields.Char()
-    session_end = fields.Datetime(compute="compute_session_end", store=True)
+    session_end = fields.Datetime(compute="compute_session_end", store=True, tracking=True)
     session_end_str = fields.Char()
     domain = fields.Char()
     replay = fields.Char()
-    violation = fields.Char()
+    violation = fields.Char(string="Challenge")
     selection = fields.Char()
     sub_selection = fields.Char()
     gaze_point = fields.Char()
     view_count = fields.Char()
     reaction_time_str = fields.Char(string="Reaction Time")
     view_time_str = fields.Char(string="View Time")
-    vr_mail_id = fields.Many2one('virsat.vr.mails', string="VR Mail")
+    vr_mail_id = fields.Many2one('virsat.vr.mails', string="VR Mail", tracking=True)
     attachment_id = fields.Many2one('ir.attachment')
-    score = fields.Integer(compute="compute_score", store=True)
+    score = fields.Integer(compute="compute_score", store=True, tracking=True)
     score_str = fields.Char()
-    # status = fields.Selection([("passed", "Passed"), ('failed', 'Failed')])
-    remark = fields.Char(string='Status')
+    remark = fields.Char(string='Status', tracking=True)
 
     @api.depends('score_str')
     def compute_score(self):
         for result in self:
-            if result.score_str.isnumeric():
-                result.score = int(result.score_str)
-            else:
+            try:
+                result.score = int(float(result.score_str))
+            except:
                 result.score = 0
 
     @api.depends('session_start_str')

--- a/virsat/models/vr_games.py
+++ b/virsat/models/vr_games.py
@@ -5,13 +5,16 @@ from datetime import datetime
 
 class VrGame(models.Model):
     _name = "vr.games"
+    _inherit = ['mail.thread']
     _description = "VR Game"
 
-    name = fields.Char()
-    code = fields.Char()
+    name = fields.Char(string="Training Module")
+    code = fields.Char(tracking=True, required=True)
     description = fields.Text()
     company_id = fields.Many2one('res.company', default=lambda self: self.env.company)
     levels_count = fields.Integer(compute='compute_level_count')
+    compute_status = fields.Selection([('percentage', 'Percentage'), ('score', 'Score')], default='percentage', tracking=True)
+    compute_status_qty = fields.Float(string="Compute Quantity", default=100, tracking=True)
 
     _sql_constraints = [
         ('code_company_uniq', 'unique(code,company_id)', 'Game code must be unique per company.'),
@@ -39,7 +42,7 @@ class VrGameLevels(models.Model):
     name = fields.Char(required=True)
     code = fields.Char(required=True)
     passing_score = fields.Integer(default=1)
-    game_id = fields.Many2one("vr.games")
+    game_id = fields.Many2one("vr.games", string="Training Module")
 
     _sql_constraints = [
         ('code_game_uniq', 'unique(code,game_id)', 'Level code must be unique per game.'),
@@ -48,20 +51,22 @@ class VrGameLevels(models.Model):
 
 class VrGameSessions(models.Model):
     _name = "vr.game.sessions"
+    _inherit = ['mail.thread']
     _description = "VR Game Sessions"
     _order = 'id desc'
 
-    name = fields.Char(string='PIN')
+    name = fields.Char(string='PIN', tracking=True)
     company_id = fields.Many2one('res.company', compute='get_company', store=True)
-    company_code = fields.Char()
+    company_code = fields.Char(tracking=True)
     vr_trainee_id = fields.Many2one('vr.trainee', compute='get_vr_trainee', string="Trainee", store=True)
     session_start_str = fields.Char(string="Session Start")
-    session_start = fields.Datetime(compute="compute_session_start", store=True)
+    session_start = fields.Datetime(compute="compute_session_start", store=True, tracking=True)
     session_end_str = fields.Char(string="Session End")
-    session_end = fields.Datetime(compute="compute_session_end", store=True)
-    game_result_ids = fields.One2many('vr.game.result', 'game_session_id')
+    session_end = fields.Datetime(compute="compute_session_end", store=True, tracking=True)
+    game_id = fields.Many2one('vr.games', string="Training Module", tracking=True)
+    game_result_ids = fields.One2many('vr.game.result', 'game_session_id', readonly=True)
     vr_mail_id = fields.Many2one('virsat.vr.mails')
-    status = fields.Selection([("passed", "Passed"), ('failed', 'Failed')], compute="compute_status", store=True)
+    status = fields.Selection([("passed", "Passed"), ('failed', 'Failed')], compute="compute_status", store=True, tracking=True)
 
     @api.depends('session_start_str')
     def compute_session_start(self):
@@ -88,8 +93,24 @@ class VrGameSessions(models.Model):
     @api.depends('game_result_ids.remark')
     def compute_status(self):
         for res in self:
-            remark = res.game_result_ids.mapped('remark')
-            res.status = 'failed' if any(s in ('Incorrect', 'Failed') for s in remark) else 'passed'
+            # remark = res.game_result_ids.mapped('remark')
+            # res.status = 'failed' if any(s in ('Incorrect', 'Failed') for s in remark) else 'passed'
+
+            passing = res.game_id.compute_status_qty
+            if res.game_id.compute_status == 'score':
+                total_score = 0
+                level_scores = {}
+                for g in res.game_result_ids:
+                    if g.level_code not in level_scores:
+                        level_scores[g.level_code] = []
+                    level_scores[g.level_code] += [g.score]
+                for k, v in level_scores.items():
+                    total_score += max(v)
+                res.status = 'passed' if total_score >= passing else 'failed'
+            else:
+                unique_violation = res.game_result_ids.mapped('violation')
+                correct = res.game_result_ids.filtered(lambda g: g.remark.lower() in ('passed', 'correct')).mapped('remark')
+                res.status = 'passed' if (len(correct) / len(set(unique_violation))) * 100 >= passing else 'failed'
 
     @api.depends('company_code')
     def get_company(self):

--- a/virsat/reports/vr_game_result_report.py
+++ b/virsat/reports/vr_game_result_report.py
@@ -19,7 +19,7 @@ class VrGameResultReport(models.Model):
     session_start = fields.Datetime()
     session_end = fields.Datetime()
     score = fields.Integer()
-    violation = fields.Char()
+    violation = fields.Char(string="Challenge")
     selection = fields.Char()
     # passing_score = fields.Integer()
     # status = fields.Selection([("passed", "Passed"), ('failed', 'Failed')], readonly=True)

--- a/virsat/views/menus.xml
+++ b/virsat/views/menus.xml
@@ -27,7 +27,8 @@
         </menuitem>
 
         <menuitem id="vr_reports_root_menu" name="Reports" sequence="40" groups="virsat.group_vr_officer">
-            <menuitem name="Game Results" id="vr_game_result_report_menu" sequence="10" action="action_vr_game_result_report"/>
+            <menuitem name="Training Sessions" id="vr_game_sessions_report_menu" sequence="10" action="action_vr_game_sessions"/>
+            <menuitem name="Training Results" id="vr_game_result_report_menu" sequence="20" action="action_vr_game_result_report"/>
         </menuitem>
 
     </menuitem>

--- a/virsat/views/res_company.xml
+++ b/virsat/views/res_company.xml
@@ -10,10 +10,10 @@
                 <page string="Other Information">
                     <group>
                         <group string="Setup">
-                            <field name="vr_trainee_pin_size"/>
+                            <field name="vr_trainee_pin_size" required="1"/>
                             <field name="vr_trainee_pin_max_size"/>
                             <field name="vr_trainee_limit"/>
-                            <field name="company_code"/>
+                            <field name="company_code" required="1"/>
                         </group>
                     </group>
                 </page>

--- a/virsat/views/vr_game_result.xml
+++ b/virsat/views/vr_game_result.xml
@@ -12,10 +12,10 @@
                     <field name="device_id"/>
                     <field name="vr_game_id"/>
                     <field name="game_level_id"/>
-                    <field name="violation"/>
                     <field name="session_start"/>
                     <field name="session_end"/>
                     <field name="reaction_time_str"/>
+                    <field name="violation"/>
                     <field name="selection"/>
                     <field name="score"/>
                     <field name="remark"/>
@@ -44,8 +44,8 @@
                                 <field name="experience"/>
                             </group>
                             <group>
-                                <field name="selection"/>
                                 <field name="violation"/>
+                                <field name="selection"/>
                                 <field name="session_start"/>
                                 <field name="session_start_str" groups="base.group_no_one"/>
                                 <field name="session_end"/>
@@ -60,6 +60,10 @@
                             </group>
                         </group>
                     </sheet>
+                    <div class="oe_chatter" groups="base.group_no_one">
+                        <field name="message_follower_ids" widget="mail_followers"/>
+                        <field name="message_ids" widget="mail_thread"/>
+                    </div>
                 </form>
             </field>
         </record>
@@ -92,8 +96,9 @@
                                     <div>Name: <field name="trainee_name" groups="virsat.group_view_vr_trainee_name"/></div>
                                     <div>Session Start: <field name="session_start"/></div>
                                     <div>Session End: <field name="session_end"/></div>
-                                    <div>Violation: <field name="violation"/></div>
-                                    <div>Selection: <field name="selection"/></div>
+                                    <div>Challenge: <field name="violation"/></div>
+                                    <div t-if="record.selection.raw_value">Selection: <field name="selection"/></div>
+                                    <div t-if="record.score.raw_value > 0">Score: <field name="score"/></div>
                                     <div class="mt-2">
                                         <t t-if="record.remark.raw_value == 'Passed' or record.remark.raw_value == 'Correct'">
                                             <div class="h1"><i class="fa fa-check-circle text-success"/> Passed</div>

--- a/virsat/views/vr_games.xml
+++ b/virsat/views/vr_games.xml
@@ -18,11 +18,21 @@
                         </h1>
                     </div>
                     <group>
-                        <field name="code"/>
-                        <field name="description"/>
-                        <field name="company_id" groups="base.group_multi_company"/>
+                        <group>
+                            <field name="code"/>
+                            <field name="description"/>
+                            <field name="company_id" groups="base.group_multi_company"/>
+                        </group>
+                        <group string="Status Computation">
+                            <field name="compute_status"/>
+                            <field name="compute_status_qty"/>
+                        </group>
                     </group>
                 </sheet>
+                <div class="oe_chatter" groups="base.group_no_one">
+                    <field name="message_follower_ids" widget="mail_followers"/>
+                    <field name="message_ids" widget="mail_thread"/>
+                </div>
             </form>
         </field>
     </record>
@@ -93,6 +103,7 @@
                 <field name="name"/>
                 <field name="session_start"/>
                 <field name="session_end"/>
+                <field name="game_id"/>
                 <field name="status"/>
                 <field name="company_code" groups="base.group_no_one"/>
                 <field name="company_id" groups="base.group_multi_company"/>
@@ -122,6 +133,7 @@
                             <field name="session_start_str" groups="base.group_no_one"/>
                             <field name="session_end"/>
                             <field name="session_end_str" groups="base.group_no_one"/>
+                            <field name="game_id"/>
                         </group>
                         <group>
                             <field name="company_code" groups="base.group_no_one"/>
@@ -129,8 +141,20 @@
                             <field name="vr_mail_id" groups="base.group_no_one" readonly="1"/>
                         </group>
                     </group>
-                    <field name="game_result_ids" readonly="1"/>
+                    <field name="game_result_ids">
+                        <tree>
+                            <field name="game_level_id" optional="hide"/>
+                            <field name="violation"/>
+                            <field name="selection"/>
+                            <field name="score" optional="hide"/>
+                            <field name="remark"/>
+                        </tree>
+                    </field>
                 </sheet>
+                <div class="oe_chatter" groups="base.group_no_one">
+                    <field name="message_follower_ids" widget="mail_followers"/>
+                    <field name="message_ids" widget="mail_thread"/>
+                </div>
             </form>
         </field>
     </record>

--- a/virsat/views/vr_mails.xml
+++ b/virsat/views/vr_mails.xml
@@ -52,7 +52,7 @@
             <field name="arch" type="xml">
                 <xpath expr="//form/sheet" position="before">
                     <header>
-                        <button name="vr_dev" type="object" string="VR Dev"/>
+                        <button name="vr_dev" type="object" string="VR Dev" groups="base.group_system"/>
                     </header>
                 </xpath>
             </field>

--- a/virsat/views/vr_trainee.xml
+++ b/virsat/views/vr_trainee.xml
@@ -7,12 +7,12 @@
             <field name="arch" type="xml">
                 <form string="Trainee">
                     <header>
-                        <button name="action_view_game_result" type="object" string="View Sessions" class="oe_highlight" attrs="{'invisible':[('game_sessions_count', '=', 0)]}"/>
+                        <button name="action_view_game_result" type="object" string="View Training Sessions" class="oe_highlight" attrs="{'invisible':[('game_sessions_count', '=', 0)]}"/>
                     </header>
                     <sheet>
                         <div class="oe_button_box" name="button_box">
                             <button name="action_view_game_result" type="object" class="oe_stat_button" icon="fa-tasks" attrs="{'invisible':[('game_sessions_count', '=', 0)]}">
-                                <field string="Game Sessions" name="game_sessions_count" widget="statinfo"/>
+                                <field string="Training Sessions" name="game_sessions_count" widget="statinfo"/>
                             </button>
                         </div>
                         <div class="oe_title" groups="virsat.group_view_vr_trainee_name">


### PR DESCRIPTION
- Get the game session by game code since the game code is connected to a company
- For the level code makes it dynamic
  - If the level code is not existing, create a new record
  - for LSR Pro, check if the level code is n/a
  - If yes, then get the violation as the level code
- Per game, add status computation by percentage or score.
  - Check also what if they repeated the game multiple times and then get a correct answer, the percentage should work
- Add log notes to games and results since we should know if someone updated them or not.
- Rename violation to challenge
